### PR TITLE
ci: report code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
     needs: lint
 
     runs-on: ubuntu-latest
+    env:
+      COVERAGE_PYTHON: "3.14"
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
@@ -72,4 +74,54 @@ jobs:
         run: uv sync --dev --resolution ${{ matrix.resolution }}
 
       - name: Run tests
-        run: uv run --no-sync pytest
+        run: |
+          if [ "${{ matrix.python-version }}" == "${{ env.COVERAGE_PYTHON }}" ]; then
+            uv run --no-sync pytest --cov --cov-report=json --cov-report=markdown --cov-report=term
+          else
+            uv run --no-sync pytest
+          fi
+
+      - name: Add coverage summary
+        if: matrix.python-version == env.COVERAGE_PYTHON
+        run: |
+          echo "## Code Coverage Report" >> $GITHUB_STEP_SUMMARY
+          cat coverage.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload coverage artifact
+        if: |
+          matrix.python-version == env.COVERAGE_PYTHON &&
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.json
+
+  badge:
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: coverage
+
+    steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+
+      - name: Update gist
+        env:
+          GH_TOKEN: ${{ secrets.GIST_TOKEN }}
+          GIST_ID: ${{ vars.GIST_ID }}
+        run: |
+          PCT=$(jq -r '.totals.percent_covered_display' coverage.json)
+          
+          if [ "$PCT" -ge 95 ]; then COLOR="brightgreen";
+          elif [ "$PCT" -ge 90 ]; then COLOR="green";
+          elif [ "$PCT" -ge 80 ]; then COLOR="yellowgreen";
+          elif [ "$PCT" -ge 70 ]; then COLOR="yellow";
+          elif [ "$PCT" -ge 60 ]; then COLOR="orange";
+          else COLOR="red"; fi
+          
+          JSON_DATA=$(printf '{"schemaVersion":1,"label":"coverage","message":"%s%%","color":"%s"}' "$PCT" "$COLOR")
+          gh gist edit "$GIST_ID" --add "coverage.json" - <<< "$JSON_DATA"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ build-backend = "uv_build"
 dev = [
     "mypy>=1.19.1",
     "pytest>=9.0.2",
+    "pytest-cov>=7.0.0",
     "pytest-examples>=0.0.18",
     "ruff>=0.14.8",
     "scipy-stubs>=1.16.3.3",
@@ -62,13 +63,20 @@ docs = [
     "pygments-styles>=0.3.0",
 ]
 
-[tool.mypy]
-files = ["src"]
-strict = true
-
 [tool.pytest]
 addopts = ["--import-mode=importlib", "--doctest-modules"]
 markers = ["slow: slow statistical tests"]
+strict = true
+
+[tool.coverage.run]
+source = ["src"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+
+[tool.mypy]
+files = ["src"]
 strict = true
 
 [tool.ruff]

--- a/src/hopkins_statistic/_typing.py
+++ b/src/hopkins_statistic/_typing.py
@@ -3,7 +3,7 @@ import sys
 if sys.version_info >= (3, 13):
     from typing import TypeAliasType
 else:
-    from typing_extensions import TypeAliasType
+    from typing_extensions import TypeAliasType  # pragma: no cover
 
 from collections.abc import Sequence
 from typing import Any


### PR DESCRIPTION
Add pytest-cov to development dependencies.
Generate coverage reports in CI workflow.
Automate badge updates via GitHub Gist.