### PR TITLE
fix: prevent input mutation for toroidal=True

### DIFF
--- a/src/hopkins_statistic/_statistic.py
+++ b/src/hopkins_statistic/_statistic.py
@@ -91,7 +91,7 @@ def hopkins(
 
     boxsize = None
     if toroidal:
-        X -= lower
+        X = np.asarray(X - lower)
         lower, upper = 0, upper - lower
         boxsize = np.nextafter(upper, np.inf)
 

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -92,3 +92,11 @@ def test_scale_and_shift_invariance(toroidal, rng):
     H1 = hopkins(X, toroidal=toroidal, rng=42)
     H2 = hopkins(2 * X + 1, toroidal=toroidal, rng=42)
     assert H2 == pytest.approx(H1)  # noqa: SIM300
+
+
+def test_input_immutability(toroidal, rng):
+    X = rng.uniform(-1, 1, size=(N, D))
+    X_copy = X.copy()
+
+    hopkins(X, toroidal=toroidal)
+    assert np.array_equal(X, X_copy)


### PR DESCRIPTION
Stop modifying `X` in-place in the toroidal branch.
Wrap shifted view of `X` in `numpy.asarray` to make mypy happy.
Test input immutability regardless of the `toroidal` option.

Fixes #9.