### PR TITLE
refactor!: drop HopkinsUndefinedWarning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- `HopkinsUndefinedWarning` and the explicit check for degenerate data;
+  degenerate cases now rely on NumPy to warn and still produce `NaN`.
+
 ## [0.3.1] - 2026-01-27
 
 ### Fixed

--- a/src/hopkins_statistic/__init__.py
+++ b/src/hopkins_statistic/__init__.py
@@ -15,8 +15,7 @@ __all__ = [
     "hopkins",
     "hopkins_test",
     "HopkinsTestResult",
-    "HopkinsUndefinedWarning",
 ]
 
 from ._inference import HopkinsTestResult, hopkins_test
-from ._statistic import HopkinsUndefinedWarning, hopkins
+from ._statistic import hopkins

--- a/src/hopkins_statistic/_inference.py
+++ b/src/hopkins_statistic/_inference.py
@@ -73,9 +73,6 @@ def hopkins_test(
     Returns:
         The result of the Hopkins test (statistic and p-value).
 
-    Warns:
-        `HopkinsUndefinedWarning`: If all observations in `X` are identical.
-
     """
     X = np.asarray(X, dtype=float)
 

--- a/src/hopkins_statistic/_statistic.py
+++ b/src/hopkins_statistic/_statistic.py
@@ -1,6 +1,5 @@
 import math
 import numbers
-import warnings
 from typing import Any
 
 import numpy as np
@@ -8,10 +7,6 @@ from numpy.typing import ArrayLike
 from scipy.spatial import KDTree
 
 from hopkins_statistic._typing import RNGLike, SeedLike
-
-
-class HopkinsUndefinedWarning(RuntimeWarning):
-    """Warning issued when the Hopkins statistic is undefined."""
 
 
 def hopkins(
@@ -46,9 +41,6 @@ def hopkins(
     Returns:
         The Hopkins statistic, a value between 0 and 1 (NaN if undefined).
 
-    Warns:
-        `HopkinsUndefinedWarning`: If all observations in `X` are identical.
-
     """
     X = np.asarray(X, dtype=float)
 
@@ -63,10 +55,6 @@ def hopkins(
         raise ValueError(msg)
 
     lower, upper = X.min(axis=0), X.max(axis=0)
-    if np.all(lower == upper):
-        msg = "All observations in X are identical."
-        warnings.warn(msg, HopkinsUndefinedWarning, stacklevel=2)
-        return math.nan
 
     boxsize = None
     if toroidal:

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -3,19 +3,19 @@ import math
 import numpy as np
 import pytest
 
-from hopkins_statistic import HopkinsUndefinedWarning, hopkins, hopkins_test
+from hopkins_statistic import hopkins, hopkins_test
 
 X_degenerate = np.ones((3, 1))
 
 
 def test_hopkins_warns_for_degenerate_data():
-    with pytest.warns(HopkinsUndefinedWarning):
+    with pytest.warns(RuntimeWarning):
         statistic = hopkins(X_degenerate)
     assert math.isnan(statistic)
 
 
 def test_hopkins_test_warns_for_degenerate_data():
-    with pytest.warns(HopkinsUndefinedWarning):
+    with pytest.warns(RuntimeWarning):
         result = hopkins_test(X_degenerate)
     assert math.isnan(result.statistic)
     assert math.isnan(result.pvalue)


### PR DESCRIPTION
Remove `HopkinsUndefinedWarning` and explicit check for degenerate data to simplify validation, as NumPy already warns and produces `NaN`.