### PR TITLE
docs: add line break before math block expression

### DIFF
--- a/docs/background.md
+++ b/docs/background.md
@@ -29,7 +29,8 @@ data in any dimension:
 >   $X \setminus \lbrace x_i \rbrace$.
 > 
 > Then the Hopkins statistic is defined as
-> $$\\ H = \frac{\sum_{i=1}^m u_i^d}{\sum_{i=1}^m u_i^d + \sum_{i=1}^m w_i^d}. $$
+> 
+> $$ H = \frac{\sum_{i=1}^m u_i^d}{\sum_{i=1}^m u_i^d + \sum_{i=1}^m w_i^d}. $$
 >  
 > Under the CSR null hypothesis, $H \sim \mathrm{Beta}(m,m)$.
 


### PR DESCRIPTION
Precede the formula with an empty line for proper rendering on GitHub.