### PR TITLE
test: avoid discouraged init file in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,10 @@ show_missing = true
 
 [tool.mypy]
 files = ["src", "tests"]
+mypy_path = "src"
 strict = true
+explicit_package_bases = true
+namespace_packages = true
 
 [[tool.mypy.overrides]]
 module = "tests.*"
@@ -100,7 +103,7 @@ ignore = [
 extend-ignore-names = ["X", "X_in", "H"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["ANN", "D", "N802", "N803", "N806", "S101"]
+"tests/*" = ["ANN", "D", "INP001", "N802", "N803", "N806", "S101"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
Delete the `__init__.py` file in the tests directory, as it is discouraged by pytest when using the recommended import mode.
Configure mypy to still treat the directory as package to allow untyped test functions.
Ignore ruff rule INP001 (implicit-namespace-package) for the tests dir.
