### PR TITLE
docs: improve usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ be computed analytically.
 pip install hopkins-statistic
 ```
 
-[//]: # (--8<-- [start:usage])
-
 ## Usage
 
 ```python
@@ -36,17 +34,13 @@ import numpy as np
 from hopkins_statistic import hopkins
 
 rng = np.random.default_rng(42)
-
-# Simple clustered example: two Gaussian blobs
-centers = np.array([[0, 0], [0, 1]])
-labels = rng.integers(len(centers), size=100)
-X = centers[labels] + rng.normal(scale=0.1, size=(100, 2))
+X = rng.uniform(size=(100, 2))
 
 statistic = hopkins(X, rng=rng)
 print(f"{statistic:.3f}")
-#> 0.771
+#> 0.514
 ```
 
 ## License
 
-[MIT](https://jo-phil.github.io/hopkins-statistic/license/)
+[MIT](https://github.com/jo-phil/hopkins-statistic/blob/main/LICENSE)

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,4 +27,28 @@ icon: lucide/house
     uv pip install hopkins-statistic
     ```
 
---8<-- "README.md:usage"
+## Usage
+
+=== "Hopkins statistic"
+
+    ```python exec="1" source="material-block" result="python { .no-copy }"
+    import numpy as np
+    from hopkins_statistic import hopkins
+
+    rng = np.random.default_rng(42)
+    X = rng.uniform(size=(100, 2))
+    
+    print(hopkins(X, rng=rng))
+    ```
+
+=== "Hopkins test"
+
+    ```python exec="1" source="material-block" result="python { .no-copy }"
+    import numpy as np
+    from hopkins_statistic import hopkins_test
+    
+    rng = np.random.default_rng(42)
+    X = rng.uniform(size=(100, 2))
+    
+    print(hopkins_test(X, rng=rng))
+    ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
 ]
 docs = [
     "changelog-slugs>=0.1.0",
+    "markdown-exec>=1.12.1",
     "mkdocstrings-python>=2.0.3",
     "zensical>=0.0.32",
 ]

--- a/zensical.toml
+++ b/zensical.toml
@@ -55,19 +55,28 @@ link = "https://pypi.org/project/hopkins-statistic/"
 [project.markdown_extensions.abbr]
 [project.markdown_extensions.admonition]
 [project.markdown_extensions.attr_list]
+[project.markdown_extensions.md_in_html]
 [project.markdown_extensions.toc]
 permalink = true
 slugify.object = "changelog_slugs.Slugifier"
 
 [project.markdown_extensions.pymdownx.arithmatex]
 generic = true
+
 [project.markdown_extensions.pymdownx.snippets]
 auto_append = ["docs/includes/glossary.md"]
 base_path = ["."]
-[project.markdown_extensions.pymdownx.superfences]
+
+[[project.markdown_extensions.pymdownx.superfences.custom_fences]]
+name = "python"
+class = "python"
+validator = "markdown_exec.validator"
+format = "markdown_exec.formatter"
+
 [project.markdown_extensions.pymdownx.tabbed]
 alternate_style = true
 combine_header_slug = true
+slugify = { object = "pymdownx.slugs.slugify", kwds = { case = "lower" } }
 
 [project.plugins.mkdocstrings.handlers.python]
 inventories = [


### PR DESCRIPTION
Shorten the example in the README for brevity and thus clarity. Add an example for using `hopkins_test` to the documentation site. Run examples in docs automatically to avoid hardcoding their outputs.