### PR TITLE
build: migrate from mypy to ty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: uv run --no-sync ruff format --check --output-format=github
 
       - name: Check typing
-        run: uv run --no-sync mypy
+        run: uv run --no-sync ty check --output-format=github
 
   test:
     needs: lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,12 +48,12 @@ build-backend = "uv_build"
 
 [dependency-groups]
 dev = [
-    "mypy>=1.19.1",
     "pytest>=9.0.2",
     "pytest-cov>=7.0.0",
     "pytest-examples>=0.0.18",
     "ruff>=0.14.8",
     "scipy-stubs>=1.16.3.3",
+    "ty>=0.0.29",
 ]
 docs = [
     "changelog-slugs>=0.1.0",
@@ -74,16 +74,8 @@ branch = true
 [tool.coverage.report]
 show_missing = true
 
-[tool.mypy]
-files = ["src", "tests"]
-mypy_path = "src"
-strict = true
-explicit_package_bases = true
-namespace_packages = true
-
-[[tool.mypy.overrides]]
-module = "tests.*"
-disallow_untyped_defs = false
+[tool.ty.rules]
+all = "error"
 
 [tool.ruff]
 line-length = 79

--- a/src/hopkins_statistic/_statistic.py
+++ b/src/hopkins_statistic/_statistic.py
@@ -82,7 +82,7 @@ def _hopkins(
 
     boxsize = None
     if toroidal:
-        X = np.asarray(X - lower)
+        X = X - lower
         lower, upper = np.zeros(d), upper - lower
         boxsize = np.nextafter(upper, np.inf)
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -122,4 +122,4 @@ def test_valid_alternative_is_accepted(alternative):
 
 def test_invalid_alternative_is_rejected():
     with pytest.raises(ValueError, match=r"Invalid alternative"):
-        hopkins_test(X, alternative="")  # type: ignore[arg-type]
+        hopkins_test(X, alternative="")  # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
Use `ty` instead of `mypy` for type checking to speed up CI.