### PR TITLE
build: drop typing_extensions dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ requires-python = ">=3.11"
 dependencies = [
     "numpy>=2.0.0",
     "scipy>=1.13.0",
-    "typing_extensions >= 4.6.0; python_version < '3.12'",
 ]
 
 keywords = [

--- a/src/hopkins_statistic/_typing.py
+++ b/src/hopkins_statistic/_typing.py
@@ -1,10 +1,3 @@
-import sys
-
-if sys.version_info >= (3, 12):
-    from typing import TypeAliasType
-else:
-    from typing_extensions import TypeAliasType  # pragma: no cover
-
 from collections.abc import Sequence
 from typing import Any, TypeAlias
 
@@ -16,13 +9,12 @@ FloatArray1D: TypeAlias = np.ndarray[tuple[int], np.dtype[np.float64]]
 FloatArray2D: TypeAlias = np.ndarray[tuple[int, int], np.dtype[np.float64]]
 
 # See SPEC 7: https://scientific-python.org/specs/spec-0007/
-RNGLike = TypeAliasType("RNGLike", Generator | BitGenerator)
-SeedLike = TypeAliasType(
-    "SeedLike",
+RNGLike: TypeAlias = Generator | BitGenerator
+SeedLike: TypeAlias = (
     int
     | np.integer[Any]
     | Sequence[int]
     | SeedSequence
-    | np.ndarray[Any, np.dtype[np.integer[Any]]],
+    | np.ndarray[Any, np.dtype[np.integer[Any]]]
 )
 ToRNG: TypeAlias = RNGLike | SeedLike | None


### PR DESCRIPTION
Avoid requiring `typing_extensions` for Python 3.11 by using `TypeAlias` instead of `TypeAliasType`. The prior use of `TypeAliasType` was mainly required for readable type hints in documentation. Since migrating from `pdoc` to `zensical` and `mkdocstrings`, this is no longer necessary.