### PR TITLE
feat: support convex hull as sampling frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `'hull'` option to the `frame` parameter for sampling from the convex hull.
+
 ### Removed
 
 - `typing_extensions` dependency for Python 3.11.

--- a/src/hopkins_statistic/_inference.py
+++ b/src/hopkins_statistic/_inference.py
@@ -3,7 +3,8 @@ from typing import Literal, NamedTuple, TypeAlias
 from numpy.typing import ArrayLike
 from scipy.stats import beta
 
-from ._statistic import Frame, _hopkins
+from ._sampling import Frame
+from ._statistic import _hopkins
 from ._typing import ToRNG
 
 Alternative: TypeAlias = Literal["clustered", "regular", "two-sided"]

--- a/src/hopkins_statistic/_inference.py
+++ b/src/hopkins_statistic/_inference.py
@@ -68,6 +68,7 @@ def hopkins_test(
         frame: Area sampling frame. Must be one of:
 
             - Literal `'bbox'` to use the axis-aligned bounding box of `X`, or
+            - Literal `'hull'` to use the convex hull of `X`, or
             - Pair `(lower, upper)` defining the bounds of a rectangular
               sampling frame. Both must be broadcastable to shape `(d,)`.
               While data points outside a given frame are ignored during

--- a/src/hopkins_statistic/_sampling.py
+++ b/src/hopkins_statistic/_sampling.py
@@ -25,6 +25,9 @@ class Box(SamplingFrame):
     def __init__(
         self, lower: ArrayLike, upper: ArrayLike, *, dim: int
     ) -> None:
+        lower = np.asarray(lower, dtype=float)
+        upper = np.asarray(upper, dtype=float)
+
         try:
             lower = np.broadcast_to(lower, (dim,))
             upper = np.broadcast_to(upper, (dim,))

--- a/src/hopkins_statistic/_sampling.py
+++ b/src/hopkins_statistic/_sampling.py
@@ -4,10 +4,21 @@ from typing import Literal, TypeAlias
 
 import numpy as np
 from numpy.typing import ArrayLike
+from scipy.spatial import ConvexHull as ScipyConvexHull
+from scipy.spatial import Delaunay, QhullError
+from scipy.special import logsumexp
 
-from ._typing import BoolArray1D, FloatArray1D, FloatArray2D, ToRNG
+from ._typing import (
+    BoolArray1D,
+    FloatArray1D,
+    FloatArray2D,
+    FloatArray3D,
+    ToRNG,
+)
 
-Frame: TypeAlias = Literal["bbox"] | tuple[ArrayLike, ArrayLike] | ArrayLike
+Frame: TypeAlias = (
+    Literal["bbox", "hull"] | tuple[ArrayLike, ArrayLike] | ArrayLike
+)
 
 
 class SamplingFrame(ABC):
@@ -50,13 +61,62 @@ class Box(SamplingFrame):
         rng = np.random.default_rng(rng)
         return rng.uniform(self.lower, self.upper, size=(m, self.dim))
 
+    @classmethod
+    def from_data(cls, X: FloatArray2D) -> "Box":
+        return cls(np.min(X, axis=0), np.max(X, axis=0), dim=X.shape[1])
+
+
+class ConvexHull(SamplingFrame):
+    simplices: FloatArray3D
+    simplex_probs: FloatArray1D
+    dim: int
+
+    def __init__(self, X: FloatArray2D) -> None:
+        try:
+            vertices = X[ScipyConvexHull(X).vertices]
+            simplices = vertices[Delaunay(vertices).simplices]
+        except QhullError as e:
+            msg = "X must span a full-dimensional convex hull"
+            raise ValueError(msg) from e
+
+        # Simplex volumes are abs(det(simplex_edges)) / dim!.
+        # The common divisor cancels out when normalizing probabilities.
+        # Perform operations in log-space for numerical stability.
+        simplex_edges = simplices[:, 1:, :] - simplices[:, :1, :]
+        _, logabsdet = np.linalg.slogdet(simplex_edges)
+        log_simplex_probs = logabsdet - logsumexp(logabsdet)
+
+        self.simplices = simplices
+        self.simplex_probs = np.exp(log_simplex_probs)
+        self.dim = X.shape[1]
+
+    def contains(self, X: FloatArray2D) -> BoolArray1D:
+        raise NotImplementedError
+
+    def sample(self, m: int, rng: ToRNG) -> FloatArray2D:
+        rng = np.random.default_rng(rng)
+
+        # Sample simplices weighted by volume with replacement.
+        sampled_simplices = rng.choice(
+            self.simplices, size=m, p=self.simplex_probs, axis=0
+        )
+
+        # Sample points uniformly from simplices via barycentric coordinates.
+        barycentric_coords = rng.dirichlet(np.ones(self.dim + 1), size=m)
+        return np.einsum("ij,ijd->id", barycentric_coords, sampled_simplices)
+
 
 def resolve_frame(X: FloatArray2D, frame: Frame) -> SamplingFrame:
     match frame:
         case "bbox":
-            return Box(np.min(X, axis=0), np.max(X, axis=0), dim=X.shape[1])
+            return Box.from_data(X)
+        case "hull":
+            # Qhull requires at least 2D data; the bbox is equivalent in 1D.
+            return ConvexHull(X) if X.shape[1] > 1 else Box.from_data(X)
+
         case [lower, upper]:
             return Box(lower, upper, dim=X.shape[1])
+
         case Sequence() | np.ndarray() if not isinstance(frame, str | bytes):
             msg = (
                 "frame must be 'bbox' or a pair of bounds (lower, upper); "

--- a/src/hopkins_statistic/_sampling.py
+++ b/src/hopkins_statistic/_sampling.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Literal, TypeAlias, cast
+from typing import Literal, TypeAlias
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -52,27 +52,20 @@ class Box(SamplingFrame):
 
 
 def resolve_frame(X: FloatArray2D, frame: Frame) -> SamplingFrame:
-    if frame == "bbox":
-        return Box(np.min(X, axis=0), np.max(X, axis=0), dim=X.shape[1])
-
-    if isinstance(frame, (str, bytes)) or not isinstance(
-        frame, (Sequence, np.ndarray)
-    ):
-        msg = (
-            "frame must be 'bbox' or a pair of bounds (lower, upper); "
-            f"got {type(frame).__name__}."
-        )
-        raise TypeError(msg)
-
-    if len(frame) != 2:
-        msg = (
-            "frame must be a pair of bounds (lower, upper); "
-            f"got {len(frame)} elements."
-        )
-        raise ValueError(msg)
-
-    lower, upper = cast("tuple[ArrayLike, ArrayLike]", frame)
-    lower = np.asarray(lower, dtype=float)
-    upper = np.asarray(upper, dtype=float)
-
-    return Box(lower, upper, dim=X.shape[1])
+    match frame:
+        case "bbox":
+            return Box(np.min(X, axis=0), np.max(X, axis=0), dim=X.shape[1])
+        case [lower, upper]:
+            return Box(lower, upper, dim=X.shape[1])
+        case Sequence() | np.ndarray() if not isinstance(frame, str | bytes):
+            msg = (
+                "frame must be 'bbox' or a pair of bounds (lower, upper); "
+                f"got {type(frame).__name__} of length {len(frame)}."
+            )
+            raise ValueError(msg)
+        case _:
+            msg = (
+                "frame must be 'bbox' or a pair of bounds (lower, upper); "
+                f"got {type(frame).__name__}."
+            )
+            raise TypeError(msg)

--- a/src/hopkins_statistic/_sampling.py
+++ b/src/hopkins_statistic/_sampling.py
@@ -1,0 +1,75 @@
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from typing import Literal, TypeAlias, cast
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+from ._typing import BoolArray1D, FloatArray1D, FloatArray2D, ToRNG
+
+Frame: TypeAlias = Literal["bbox"] | tuple[ArrayLike, ArrayLike] | ArrayLike
+
+
+class SamplingFrame(ABC):
+    @abstractmethod
+    def contains(self, X: FloatArray2D) -> BoolArray1D: ...
+
+    @abstractmethod
+    def sample(self, m: int, rng: ToRNG) -> FloatArray2D: ...
+
+
+class Box(SamplingFrame):
+    lower: FloatArray1D
+    upper: FloatArray1D
+
+    def __init__(
+        self, lower: ArrayLike, upper: ArrayLike, *, dim: int
+    ) -> None:
+        try:
+            lower = np.broadcast_to(lower, (dim,))
+            upper = np.broadcast_to(upper, (dim,))
+        except ValueError:
+            msg = "bounds must each be scalar or match the data dimension"
+            raise ValueError(msg) from None
+
+        if np.any(lower > upper):
+            msg = "lower bounds must be lower than upper bounds"
+            raise ValueError(msg)
+
+        self.lower = lower
+        self.upper = upper
+        self.dim = dim
+
+    def contains(self, X: FloatArray2D) -> BoolArray1D:
+        return np.all((self.lower <= X) & (self.upper >= X), axis=1)
+
+    def sample(self, m: int, rng: ToRNG) -> FloatArray2D:
+        rng = np.random.default_rng(rng)
+        return rng.uniform(self.lower, self.upper, size=(m, self.dim))
+
+
+def resolve_frame(X: FloatArray2D, frame: Frame) -> SamplingFrame:
+    if frame == "bbox":
+        return Box(np.min(X, axis=0), np.max(X, axis=0), dim=X.shape[1])
+
+    if isinstance(frame, (str, bytes)) or not isinstance(
+        frame, (Sequence, np.ndarray)
+    ):
+        msg = (
+            "frame must be 'bbox' or a pair of bounds (lower, upper); "
+            f"got {type(frame).__name__}."
+        )
+        raise TypeError(msg)
+
+    if len(frame) != 2:
+        msg = (
+            "frame must be a pair of bounds (lower, upper); "
+            f"got {len(frame)} elements."
+        )
+        raise ValueError(msg)
+
+    lower, upper = cast("tuple[ArrayLike, ArrayLike]", frame)
+    lower = np.asarray(lower, dtype=float)
+    upper = np.asarray(upper, dtype=float)
+
+    return Box(lower, upper, dim=X.shape[1])

--- a/src/hopkins_statistic/_sampling.py
+++ b/src/hopkins_statistic/_sampling.py
@@ -107,6 +107,8 @@ class ConvexHull(SamplingFrame):
 
 
 def resolve_frame(X: FloatArray2D, frame: Frame) -> SamplingFrame:
+    rule = "frame must be 'bbox' or a pair of bounds (lower, upper)"
+
     match frame:
         case "bbox":
             return Box.from_data(X)
@@ -118,14 +120,8 @@ def resolve_frame(X: FloatArray2D, frame: Frame) -> SamplingFrame:
             return Box(lower, upper, dim=X.shape[1])
 
         case Sequence() | np.ndarray() if not isinstance(frame, str | bytes):
-            msg = (
-                "frame must be 'bbox' or a pair of bounds (lower, upper); "
-                f"got {type(frame).__name__} of length {len(frame)}."
-            )
+            msg = f"{rule}; got {type(frame).__name__} of length {len(frame)}."
             raise ValueError(msg)
         case _:
-            msg = (
-                "frame must be 'bbox' or a pair of bounds (lower, upper); "
-                f"got {type(frame).__name__}."
-            )
+            msg = f"{rule}; got {type(frame).__name__}."
             raise TypeError(msg)

--- a/src/hopkins_statistic/_statistic.py
+++ b/src/hopkins_statistic/_statistic.py
@@ -1,15 +1,12 @@
 import math
 import numbers
-from collections.abc import Sequence
-from typing import Literal, TypeAlias, cast
 
 import numpy as np
 from numpy.typing import ArrayLike
 from scipy.spatial import KDTree
 
+from ._sampling import Box, Frame, SamplingFrame, resolve_frame
 from ._typing import FloatArray, FloatArray1D, FloatArray2D, ToRNG
-
-Frame: TypeAlias = Literal["bbox"] | tuple[ArrayLike, ArrayLike] | ArrayLike
 
 
 def hopkins(
@@ -71,7 +68,6 @@ def _hopkins(
     X = np.asarray(X, dtype=float)
 
     d = _validate_shape(X)
-    lower, upper = _parse_frame(X, frame)
     toroidal = _parse_toroidal(toroidal)
     power = _parse_power(power, d)
     rng = np.random.default_rng(rng)
@@ -80,23 +76,21 @@ def _hopkins(
         msg = "X must contain only finite values; found NaN or inf."
         raise ValueError(msg)
 
+    implicit_frame = isinstance(frame, str)
+    frame: SamplingFrame = resolve_frame(X, frame)
+
     boxsize = None
     if toroidal:
-        X = X - lower
-        lower, upper = np.zeros(d), upper - lower
-        boxsize = np.nextafter(upper, np.inf)
+        X, frame, boxsize = _apply_toroidal_topology(X, frame)
 
-    if frame != "bbox":
-        X_in = X[np.all((lower <= X) & (upper >= X), axis=1)]
-        if toroidal and len(X_in) < len(X):
-            msg = "Points must not be outside the frame in toroidal topology."
-            raise ValueError(msg)
-    else:
-        X_in = X
+    X_in = X if implicit_frame else X[frame.contains(X)]
+    if toroidal and len(X_in) < len(X):
+        msg = "Points must not be outside the frame in toroidal topology."
+        raise ValueError(msg)
 
     m = _parse_m(m, len(X_in))
 
-    null_sample = rng.uniform(lower, upper, size=(m, d))
+    null_sample = frame.sample(m, rng)
     data_sample = rng.choice(X_in, size=m, replace=False, axis=0)
 
     tree = KDTree(X, boxsize=boxsize)
@@ -107,6 +101,23 @@ def _hopkins(
     w_sum = np.sum(w**power)
 
     return float(u_sum / (u_sum + w_sum)), m
+
+
+def _apply_toroidal_topology(
+    X: FloatArray2D, frame: SamplingFrame
+) -> tuple[FloatArray2D, SamplingFrame, FloatArray1D]:
+    if not isinstance(frame, Box):
+        msg = "toroidal topology requires a rectangular frame"
+        raise TypeError(msg)
+
+    X = X - frame.lower
+    frame = Box(
+        np.zeros_like(frame.lower),
+        frame.upper - frame.lower,
+        dim=X.shape[1],
+    )
+
+    return X, frame, np.nextafter(frame.upper, np.inf)
 
 
 def _validate_shape(X: FloatArray) -> int:
@@ -140,47 +151,6 @@ def _parse_m(m: int | float, n: int) -> int:
 
     msg = f"m must be int or float; got {type(m).__name__}."
     raise TypeError(msg)
-
-
-def _parse_frame(
-    X: FloatArray2D, frame: Frame
-) -> tuple[FloatArray1D, FloatArray1D]:
-    if frame == "bbox":
-        return X.min(axis=0), X.max(axis=0)
-
-    if isinstance(frame, (str, bytes)) or not isinstance(
-        frame, (Sequence, np.ndarray)
-    ):
-        msg = (
-            "frame must be 'bbox' or a pair of bounds (lower, upper); "
-            f"got {type(frame).__name__}."
-        )
-        raise TypeError(msg)
-
-    if len(frame) != 2:
-        msg = (
-            "frame must be a pair of bounds (lower, upper); "
-            f"got {len(frame)} elements."
-        )
-        raise ValueError(msg)
-
-    lower, upper = cast("tuple[ArrayLike, ArrayLike]", frame)
-    lower = np.asarray(lower, dtype=float)
-    upper = np.asarray(upper, dtype=float)
-
-    msg = "lower and upper bounds must each be broadcastable to shape (d,)."
-    try:
-        shape = np.broadcast_shapes(lower.shape, upper.shape, (X.shape[1],))
-    except ValueError:
-        raise ValueError(msg) from None
-    if shape != (X.shape[1],):
-        raise ValueError(msg)
-
-    if np.any(lower > upper):
-        msg = "lower bounds must be less than upper bounds."
-        raise ValueError(msg)
-
-    return lower, upper
 
 
 def _parse_toroidal(toroidal: bool) -> bool:  # noqa: FBT001

--- a/src/hopkins_statistic/_statistic.py
+++ b/src/hopkins_statistic/_statistic.py
@@ -108,7 +108,7 @@ def _apply_toroidal_topology(
 ) -> tuple[FloatArray2D, SamplingFrame, FloatArray1D]:
     if not isinstance(frame, Box):
         msg = "toroidal topology requires a rectangular frame"
-        raise TypeError(msg)
+        raise ValueError(msg)  # noqa: TRY004
 
     X = X - frame.lower
     frame = Box(

--- a/src/hopkins_statistic/_statistic.py
+++ b/src/hopkins_statistic/_statistic.py
@@ -36,6 +36,7 @@ def hopkins(
         frame: Area sampling frame. Must be one of:
 
             - Literal `'bbox'` to use the axis-aligned bounding box of `X`, or
+            - Literal `'hull'` to use the convex hull of `X`, or
             - Pair `(lower, upper)` defining the bounds of a rectangular
               sampling frame. Both must be broadcastable to shape `(d,)`.
               While data points outside a given frame are ignored during

--- a/src/hopkins_statistic/_typing.py
+++ b/src/hopkins_statistic/_typing.py
@@ -8,6 +8,9 @@ BoolArray1D: TypeAlias = np.ndarray[tuple[int], np.dtype[np.bool_]]
 FloatArray: TypeAlias = np.ndarray[Any, np.dtype[np.float64]]
 FloatArray1D: TypeAlias = np.ndarray[tuple[int], np.dtype[np.float64]]
 FloatArray2D: TypeAlias = np.ndarray[tuple[int, int], np.dtype[np.float64]]
+FloatArray3D: TypeAlias = np.ndarray[
+    tuple[int, int, int], np.dtype[np.float64]
+]
 
 # See SPEC 7: https://scientific-python.org/specs/spec-0007/
 RNGLike: TypeAlias = Generator | BitGenerator

--- a/src/hopkins_statistic/_typing.py
+++ b/src/hopkins_statistic/_typing.py
@@ -4,6 +4,7 @@ from typing import Any, TypeAlias
 import numpy as np
 from numpy.random import BitGenerator, Generator, SeedSequence
 
+BoolArray1D: TypeAlias = np.ndarray[tuple[int], np.dtype[np.bool_]]
 FloatArray: TypeAlias = np.ndarray[Any, np.dtype[np.float64]]
 FloatArray1D: TypeAlias = np.ndarray[tuple[int], np.dtype[np.float64]]
 FloatArray2D: TypeAlias = np.ndarray[tuple[int, int], np.dtype[np.float64]]

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -1,11 +1,13 @@
 import itertools
 from copy import deepcopy
+from unittest.mock import patch
 
 import numpy as np
 import pytest
 from scipy.stats import beta
 
 from hopkins_statistic import hopkins, hopkins_test
+from hopkins_statistic._sampling import ConvexHull
 
 N, D = 100, 2  # smallest reasonable shape for behavioral tests
 
@@ -13,7 +15,7 @@ N, D = 100, 2  # smallest reasonable shape for behavioral tests
 @pytest.mark.slow
 @pytest.mark.parametrize("d", [2, 3, 5], ids=lambda val: f"d={val}")
 @pytest.mark.parametrize("edge_correction", [None, "buffer", "toroidal"])
-def test_null(d, edge_correction, rng):
+def test_beta_moments_under_null(d, edge_correction, rng):
     m = N // 10
 
     # Using buffer zones to correct for edge effects, specify a frame that
@@ -31,6 +33,20 @@ def test_null(d, edge_correction, rng):
 
     assert np.mean(Hs) == pytest.approx(0.5, abs=tol)
     assert np.std(Hs) == pytest.approx(beta.std(m, m), abs=tol)
+
+
+@pytest.mark.parametrize("d", [2, 3, 5], ids=lambda val: f"d={val}")
+def test_beta_moments_under_null_in_convex_hull(d, rng):
+    hull = ConvexHull(rng.normal(size=(2**d, d)))
+    X = hull.sample(N, rng)
+
+    with patch(  # Avoid recomputing the hull every iteration
+        "hopkins_statistic._statistic.resolve_frame", new=lambda _, __: hull
+    ):
+        Hs = [hopkins(X, m=10, frame="hull", rng=rng) for _ in range(1000)]
+
+    assert np.mean(Hs) == pytest.approx(0.5, abs=0.05)
+    assert np.std(Hs) == pytest.approx(beta.std(10, 10), abs=0.05)
 
 
 @pytest.mark.parametrize("seed", range(10))
@@ -85,6 +101,18 @@ def test_toroidal_vertices(rng):
     X = list(itertools.product([0, 1], repeat=7))
     assert hopkins(X, toroidal=False, rng=rng) < 0.3
     assert hopkins(X, toroidal=True) == 1.0
+
+
+def test_convex_hull_on_rotated_data(rng):
+    X = rng.uniform(size=(N, D))
+
+    # Rotate X to be clustered in its bounding box but not in its convex hull
+    c, s = np.cos(np.radians(45)), np.sin(np.radians(45))
+    R = np.array([[c, -s], [s, c]])
+    X = X @ R.T
+
+    assert hopkins(X, rng=42) > 0.7
+    assert 0.4 < hopkins(X, frame="hull", rng=42) < 0.6
 
 
 def test_input_immutability(toroidal, rng):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -70,7 +70,7 @@ def test_frame_must_be_of_valid_type(hopkins_func, frame):
 
 @pytest.mark.parametrize("frame", [[], [1, 2, 3]])
 def test_frame_must_be_a_pair(hopkins_func, frame):
-    with pytest.raises(ValueError, match=r"must be a pair"):
+    with pytest.raises(ValueError, match=r"frame must be 'bbox' or a pair"):
         hopkins_func(X, frame=frame)
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -76,12 +76,12 @@ def test_frame_must_be_a_pair(hopkins_func, frame):
 
 @pytest.mark.parametrize("X", [X, np.empty((3, 2))])
 def test_frame_must_be_broadcastable(hopkins_func, X):
-    with pytest.raises(ValueError, match=r"broadcastable to shape \(d,\)"):
+    with pytest.raises(ValueError, match=r"each be scalar or match the data"):
         hopkins_func(X, frame=(0, np.ones(3)))
 
 
 def test_frame_upper_bounds_must_be_feasible(hopkins_func):
-    with pytest.raises(ValueError, match=r"lower bounds must be less"):
+    with pytest.raises(ValueError, match=r"lower bounds must be lower"):
         hopkins_func(X, frame=(1, 0))
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -95,6 +95,12 @@ def test_toroidal_must_be_bool(hopkins_func):
         hopkins_func(X, toroidal=1)
 
 
+def test_toroidal_topology_requires_rectangular_frame(hopkins_func):
+    X = [[0, 0], [0, 1], [1, 1]]  # Qhull requires at least 2D data.
+    with pytest.raises(ValueError, match=r"requires a rectangular frame"):
+        hopkins_func(X, frame="hull", toroidal=True)
+
+
 @pytest.mark.parametrize("power", [True, "1"])
 def test_power_must_be_numeric(power):
     with pytest.raises(TypeError, match=r"power must be a real number"):


### PR DESCRIPTION
Add an option for using the convex hull of the data as sampling frame.
Refactor the sampling logic to enable a straightforward implementation.
Test that using this option has the desired effect.