### PR TITLE
fix: handle NumPy arrays in frame resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `ValueError` when a NumPy array was passed as `frame`.
+
 [//]: # (--8<-- [start:released])
 
 ## [0.6.0] - 2026-05-07

--- a/src/hopkins_statistic/_sampling.py
+++ b/src/hopkins_statistic/_sampling.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
 from typing import Literal, TypeAlias
 
 import numpy as np
@@ -110,17 +109,17 @@ def resolve_frame(X: FloatArray2D, frame: Frame) -> SamplingFrame:
     rule = "frame must be 'bbox', 'hull', or a pair of bounds (lower, upper)"
 
     match frame:
-        case "bbox":
+        case str("bbox"):
             return Box.from_data(X)
-        case "hull":
+        case str("hull"):
             # Qhull requires at least 2D data; the bbox is equivalent in 1D.
             return ConvexHull(X) if X.shape[1] > 1 else Box.from_data(X)
 
-        case [lower, upper]:
-            return Box(lower, upper, dim=X.shape[1])
+        case ([*_] | np.ndarray()) as bounds if len(bounds) == 2:
+            return Box(bounds[0], bounds[1], dim=X.shape[1])
 
-        case Sequence() | np.ndarray() if not isinstance(frame, str | bytes):
-            msg = f"{rule}; got {type(frame).__name__} of length {len(frame)}."
+        case ([*_] | np.ndarray()) as bad:
+            msg = f"{rule}; got {type(bad).__name__} of length {len(bad)}."
             raise ValueError(msg)
         case _:
             msg = f"{rule}; got {type(frame).__name__}."

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -62,6 +62,11 @@ def test_m_float_must_satisfy_bounds(hopkins_func, m):
         hopkins_func(X, m=m)
 
 
+@pytest.mark.parametrize("frame", ["bbox", "hull", (0, 1), np.array([0, 1])])
+def test_valid_frame_is_accepted(frame):
+    assert 0 < hopkins(X, frame=frame) < 1
+
+
 @pytest.mark.parametrize("frame", ["box", 1])
 def test_frame_must_be_of_valid_type(hopkins_func, frame):
     with pytest.raises(TypeError, match=r"must be 'bbox', 'hull', or a pair"):


### PR DESCRIPTION
Match "bbox" and "hull" only for string inputs to prevent NumPy arrays from raising a ValueError due to the ambiguous truth value of arrays. Update the explicit-bounds pattern to also match NumPy arrays. Replace `Sequence()` with `[*_]` in the error case for consistency, making the `if not isinstance(frame, str | bytes)` redundant.

Fixes #31