### PR TITLE
feat: export type aliases of parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Alternative`, `Frame`, and `ToRNG` type aliases for function parameters.
+
 ### Changed
 
 - `frame='hull'` sampling for improved performance, changing seeded results.

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,3 +4,12 @@ icon: lucide/code
 ---
 
 # ::: hopkins_statistic
+    options:
+      group_by_category: false
+      members:
+        - hopkins
+        - hopkins_test
+        - HopkinsTestResult
+        - Alternative
+        - Frame
+        - ToRNG

--- a/src/hopkins_statistic/__init__.py
+++ b/src/hopkins_statistic/__init__.py
@@ -6,10 +6,15 @@ Functions:
 """
 
 __all__ = [
+    "Alternative",
+    "Frame",
     "HopkinsTestResult",
+    "ToRNG",
     "hopkins",
     "hopkins_test",
 ]
 
-from ._inference import HopkinsTestResult, hopkins_test
+from ._inference import Alternative, HopkinsTestResult, hopkins_test
+from ._sampling import Frame
 from ._statistic import hopkins
+from ._typing import ToRNG

--- a/src/hopkins_statistic/_inference.py
+++ b/src/hopkins_statistic/_inference.py
@@ -8,6 +8,7 @@ from ._statistic import _hopkins
 from ._typing import ToRNG
 
 Alternative: TypeAlias = Literal["clustered", "regular", "two-sided"]
+"""Alternative hypothesis for [`hopkins_test`][]."""
 
 
 class HopkinsTestResult(NamedTuple):

--- a/src/hopkins_statistic/_sampling.py
+++ b/src/hopkins_statistic/_sampling.py
@@ -18,6 +18,7 @@ from ._typing import (
 Frame: TypeAlias = (
     Literal["bbox", "hull"] | tuple[ArrayLike, ArrayLike] | ArrayLike
 )
+"""Sampling frame for [`hopkins`][] and [`hopkins_test`][]."""
 
 
 class SamplingFrame(ABC):

--- a/src/hopkins_statistic/_typing.py
+++ b/src/hopkins_statistic/_typing.py
@@ -13,12 +13,14 @@ FloatArray3D: TypeAlias = np.ndarray[
 ]
 
 # See SPEC 7: https://scientific-python.org/specs/spec-0007/
-RNGLike: TypeAlias = Generator | BitGenerator
-SeedLike: TypeAlias = (
-    int
+ToRNG: TypeAlias = (
+    Generator
+    | BitGenerator
+    | int
     | np.integer[Any]
     | Sequence[int]
     | SeedSequence
     | np.ndarray[Any, np.dtype[np.integer[Any]]]
+    | None
 )
-ToRNG: TypeAlias = RNGLike | SeedLike | None
+"""Random number generator or seed to be passed to [`numpy.random.default_rng`][]."""


### PR DESCRIPTION
Type aliases for parameters of public functions are user-facing when used in type hints and documentation. Therefore, they should be public.