### PR TITLE
chore(ty): ignore missing override decorators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ show_missing = true
 
 [tool.ty.rules]
 all = "error"
+missing-override-decorator = "ignore"
 
 [tool.ruff]
 line-length = 79


### PR DESCRIPTION
Adding override decorators to methods in a private module does not justify introducing a dependency on `typing_extensions` for Python 3.11.