### PR TITLE
test: convert parametrization values to list

### DIFF
--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -2,6 +2,6 @@ import pytest
 from pytest_examples import find_examples
 
 
-@pytest.mark.parametrize("example", find_examples("README.md"), ids=str)
+@pytest.mark.parametrize("example", list(find_examples("README.md")), ids=str)
 def test_examples(example, eval_example):
     eval_example.run_print_check(example)


### PR DESCRIPTION
Fix the deprecation warning for passing a non-collection iterable to `pytest.mark.parametrize`.